### PR TITLE
Send password jest test#43

### DIFF
--- a/app/socket-apis/__tests__/send-password.js
+++ b/app/socket-apis/__tests__/send-password.js
@@ -58,11 +58,13 @@ describe('setup test db', ()=>{
 describe('sendPassword function', ()=> {
     let mockEmail = 'success@email.com'
     let mockReturnTo = '/join'
+    // prevents host from being undefined when running jest tests
+    const mockThisObj = { handshake : { headers : { host : 'localhost:3011'}}}
 
     it('should execute callback function with "User not found" argument if email not in db', async ()=>{
       let mockCb = jest.fn()
       mockEmail = 'missing@email.com'
-      await sendPassword(mockEmail, mockReturnTo, mockCb)
+      await sendPassword.call( mockThisObj, mockEmail, mockReturnTo, mockCb)
       expect(mockCb).toHaveBeenCalledWith({ error: 'User not found'})
     })
 
@@ -70,7 +72,7 @@ describe('sendPassword function', ()=> {
       let mockCb = jest.fn()
       mockEmail = 'success@email.com'
       SibSendTransacEmail.mockImplementation(() => false)
-      await sendPassword(mockEmail, mockReturnTo, mockCb)
+      await sendPassword.call( mockThisObj, mockEmail, mockReturnTo, mockCb)
       expect(mockCb).toHaveBeenCalledWith('error sending reset password email')
     })
 
@@ -78,7 +80,7 @@ describe('sendPassword function', ()=> {
       let mockCb = jest.fn()
       mockEmail = 'success@email.com'
       SibSendTransacEmail.mockImplementation(() => true)
-      await sendPassword(mockEmail, mockReturnTo, mockCb)
+      await sendPassword.call( mockThisObj, mockEmail, mockReturnTo, mockCb)
       expect(mockCb).toHaveBeenCalledWith()
       expect(mockCb).toHaveBeenCalledTimes(1)
     })

--- a/app/socket-apis/__tests__/send-password.js
+++ b/app/socket-apis/__tests__/send-password.js
@@ -1,0 +1,66 @@
+const { Mongo } = require('@enciv/mongo-collections')
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { beforeAll } from '@jest/globals'
+import sendPassword from '../send-password'
+import { SibGetTemplateId, SibSendTransacEmail } from '../../lib/send-in-blue-transactional'
+const User = require('../../models/user')
+
+// dummy out logger for tests
+if (!global.logger) {
+  global.logger = console
+}
+
+jest.mock('../../lib/send-in-blue-transactional', ()=>({
+  SibGetTemplateId: jest.fn(()=> 'test'),
+  SibSendTransacEmail: jest.fn(()=> 'test2'),
+}))
+
+test('correct creation of mock functions', ()=>{
+  expect(jest.isMockFunction(SibGetTemplateId)).toBeTruthy()
+  expect(jest.isMockFunction(SibSendTransacEmail)).toBeTruthy()
+})
+
+let MemoryServer
+beforeAll(async () => {
+  MemoryServer = await MongoMemoryServer.create()
+  const uri = MemoryServer.getUri()
+  await Mongo.connect(uri)
+})
+
+afterAll(async () => {
+  Mongo.disconnect()
+  MemoryServer.stop()
+})
+
+describe('setup test db', ()=>{
+  
+  beforeAll(async () => {
+    const dbUser = { email: 'success@email.com', password: 'password', firstName: 'Test', lastName: 'User' }
+    const createdUser = await User.create(dbUser)
+  })
+
+  test('the db should contain 1 document', async () => {
+    
+    const count = await User.countDocuments({})
+    expect(count).toBe(1)
+  })
+
+  test('Test user should exist', async () => {
+    const user = await User.findOne({ email: 'success@email.com'})
+    expect(user.email).toBe('success@email.com')
+    expect(user.firstName).toBe('Test')
+    expect(user.lastName).toBe('User')
+  })
+})
+
+describe('sendPassword function', ()=> {
+    let mockEmail = 'success@email.com'
+    let mockReturnTo = '/join'
+    let mockCb = jest.fn()
+    
+    it('should execute callback function with "User not found" argument if email not in db', async ()=>{
+      mockEmail = 'missing@email.com'
+      await sendPassword(mockEmail, mockReturnTo, mockCb)
+      expect(mockCb).toHaveBeenCalledWith({ error: 'User not found'})
+    })
+})

--- a/app/socket-apis/send-password.js
+++ b/app/socket-apis/send-password.js
@@ -5,6 +5,8 @@ import { SibGetTemplateId, SibSendTransacEmail } from '../lib/send-in-blue-trans
 
 let templateId
 
+const env = process.env.NODE_ENV || 'development'
+
 async function sendResetPasswordEmail(host, toAddress, activationKey, activationToken, returnToPath) {
   logger.debug('sending password reset email to ', toAddress)
   if (!templateId) {
@@ -42,8 +44,9 @@ async function sendResetPasswordEmail(host, toAddress, activationKey, activation
 }
 
 async function sendPassword(email, returnTo, cb) {
-  const { host } = this.handshake.headers
-
+  // prevents host from being undefined when running jest tests
+  const { host }  = env == 'development'? { host: 'localhost:3011' } : this.handshake.headers
+  
   await User.findOne({ email })
     .then(async user => {
       if (!user) {

--- a/app/socket-apis/send-password.js
+++ b/app/socket-apis/send-password.js
@@ -42,7 +42,7 @@ async function sendResetPasswordEmail(host, toAddress, activationKey, activation
 }
 
 async function sendPassword(email, returnTo, cb) {
-  const { host }  = this.handshake.headers
+  const { host } = this.handshake.headers
 
   await User.findOne({ email })
     .then(async user => {

--- a/app/socket-apis/send-password.js
+++ b/app/socket-apis/send-password.js
@@ -5,8 +5,6 @@ import { SibGetTemplateId, SibSendTransacEmail } from '../lib/send-in-blue-trans
 
 let templateId
 
-const env = process.env.NODE_ENV || 'development'
-
 async function sendResetPasswordEmail(host, toAddress, activationKey, activationToken, returnToPath) {
   logger.debug('sending password reset email to ', toAddress)
   if (!templateId) {
@@ -44,9 +42,8 @@ async function sendResetPasswordEmail(host, toAddress, activationKey, activation
 }
 
 async function sendPassword(email, returnTo, cb) {
-  // prevents host from being undefined when running jest tests
-  const { host }  = env == 'development'? { host: 'localhost:3011' } : this.handshake.headers
-  
+  const { host }  = this.handshake.headers
+
   await User.findOne({ email })
     .then(async user => {
       if (!user) {


### PR DESCRIPTION
Created Jest tests for `sendPassword` function located at `app/socket-apis/send-password.js`

Tests check for expected outcomes for the following scenarios:

- When the email address provided doesn't match a user within the db.
- When the reset password email fails to send.
- When the email address provided matches a user within the db and the reset password email successfully sends.


Resolves #43 